### PR TITLE
Change file FlutterStatusbarcolorPlugin.m

### DIFF
--- a/ios/Classes/FlutterStatusbarcolorPlugin.m
+++ b/ios/Classes/FlutterStatusbarcolorPlugin.m
@@ -47,7 +47,11 @@ static NSInteger statusBarViewTag = 38482458385;
     if ([usewhiteforeground boolValue]) {
       [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent animated:YES];
     } else {
-      [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault animated:YES];
+        if (@available(iOS 13, *)) {
+            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDarkContent animated:YES];
+        }else{
+            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault animated:YES];
+        }
     }
     result(nil);
   } else if ([@"getnavigationbarcolor" isEqualToString:call.method]) {


### PR DESCRIPTION
The method useWhiteForeground set statusbar style Light or Default if true or false.
With dark mode do iOS, the default theme is Light. In this case the method should be check if is on iOS 13, to change to darkContent.

On my app, this works like a charm. 